### PR TITLE
Typecasting to uint8_t to remove ambiguity in compiler

### DIFF
--- a/src/SparkFun_I2C_Mux_Arduino_Library.cpp
+++ b/src/SparkFun_I2C_Mux_Arduino_Library.cpp
@@ -74,7 +74,7 @@ uint8_t QWIICMUX::getPort()
 {
   //Read the current mux settings
   //_i2cPort->beginTransmission(_deviceAddress); <- Don't do this!
-  _i2cPort->requestFrom(_deviceAddress, 1);
+  _i2cPort->requestFrom(_deviceAddress, uint8_t(1));
   if (!_i2cPort->available())
     return (255); //Error
   uint8_t portBits = _i2cPort->read();
@@ -106,7 +106,7 @@ uint8_t QWIICMUX::getPortState()
 {
   //Read the current mux settings
   //_i2cPort->beginTransmission(_deviceAddress); <- Don't do this!
-  _i2cPort->requestFrom(_deviceAddress, 1);
+  _i2cPort->requestFrom(_deviceAddress, uint8_t(1));
   return (_i2cPort->read());
 }
 


### PR DESCRIPTION
The Arduino _wire_ library accepts multiple different arguments for the function _requestFrom_, one utilising two arguments of type _uint8_t_ and the other utilising two type _int_ arguments. The Arduino IDE compiler will warn of an ambiguous function, as _1_ and __i2cPort_ are not explicitly defined as _uint8_t_.

This fork simply typecasts _1_ to _uint8_t_ to remove the ambiguity and therefore avoid warnings at compile time. Tested to work in Arduino 1.8.15.

Log of compiler warnings attached.
[CompilerWarnings.log](https://github.com/sparkfun/SparkFun_I2C_Mux_Arduino_Library/files/6974500/CompilerWarnings.log)